### PR TITLE
Adjusted repo URL for README

### DIFF
--- a/README
+++ b/README
@@ -3,7 +3,7 @@ cppnanomsg: C++ binding for nanomsg library
 
 To build:
 
-1. git clone git@github.com:250bpm/cppnanomsg.git
+1. git clone git@github.com:nanomsg/cppnanomsg.git
 2. cd cppnanomsg
 4. mkdir build
 5. cd build


### PR DESCRIPTION
The repo is now at nanomsg/cppnanomsg. The README still contained an old url.
